### PR TITLE
Set modOrder flag (wrap key data) + err check

### DIFF
--- a/crypto/bls12381/bls12381.go
+++ b/crypto/bls12381/bls12381.go
@@ -54,7 +54,11 @@ func (privKey PrivKey) Bytes() []byte {
 // If these conditions aren't met, Sign will panic or produce an
 // incorrect signature.
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
-	blsPrivateKey, _ := bls.PrivateKeyFromBytes(privKey, false)
+	// set modOrder flag to true so that too big random bytes will wrap around and be a valid key
+	blsPrivateKey, err := bls.PrivateKeyFromBytes(privKey, true)
+	if err != nil {
+		return nil, err
+	}
 	insecureSignature := blsPrivateKey.SignInsecure(msg)
 	return insecureSignature.Serialize(), nil
 }
@@ -63,7 +67,13 @@ func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 //
 // Panics if the private key is not initialized.
 func (privKey PrivKey) PubKey() crypto.PubKey {
-	blsPrivateKey, _ := bls.PrivateKeyFromBytes(privKey, false)
+	// set modOrder flag to true so that too big random bytes will wrap around and be a valid key
+	blsPrivateKey, err := bls.PrivateKeyFromBytes(privKey, true)
+	if err != nil {
+		// should probably change method sign to return an error but since
+		// that's not available just panic...
+		panic("bad key")
+	}
 	publicKeyBytes := blsPrivateKey.PublicKey().Serialize()
 	return PubKey(publicKeyBytes)
 }
@@ -140,9 +150,21 @@ func (pubKey PubKey) VerifyBytes(msg []byte, sig []byte) bool {
 	if len(sig) != SignatureSize {
 		return false
 	}
-	publicKey, _ := bls.PublicKeyFromBytes(pubKey)
-	aggregationInfo := bls.AggregationInfoFromMsg(publicKey, msg)
-	blsSignature, _ := bls.SignatureFromBytesWithAggregationInfo(sig, aggregationInfo)
+	publicKey, err := bls.PublicKeyFromBytes(pubKey)
+	if err != nil {
+		// maybe log/panic?
+		return false
+	}
+	aggregationInfo, err := bls.AggregationInfoFromMsg(publicKey, msg)
+	if err != nil {
+		// maybe log/panic?
+		return false
+	}
+	blsSignature, err := bls.SignatureFromBytesWithAggregationInfo(sig, aggregationInfo)
+	if err != nil {
+		// maybe log/panic?
+		return false
+	}
 	return blsSignature.Verify()
 }
 

--- a/crypto/bls12381/bls12381.go
+++ b/crypto/bls12381/bls12381.go
@@ -54,7 +54,7 @@ func (privKey PrivKey) Bytes() []byte {
 // If these conditions aren't met, Sign will panic or produce an
 // incorrect signature.
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
-	blsPrivateKey, _ := bls.PrivateKeyFromBytes(privKey,false)
+	blsPrivateKey, _ := bls.PrivateKeyFromBytes(privKey, false)
 	insecureSignature := blsPrivateKey.SignInsecure(msg)
 	return insecureSignature.Serialize(), nil
 }
@@ -63,7 +63,7 @@ func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 //
 // Panics if the private key is not initialized.
 func (privKey PrivKey) PubKey() crypto.PubKey {
-	blsPrivateKey, _ := bls.PrivateKeyFromBytes(privKey,false)
+	blsPrivateKey, _ := bls.PrivateKeyFromBytes(privKey, false)
 	publicKeyBytes := blsPrivateKey.PublicKey().Serialize()
 	return PubKey(publicKeyBytes)
 }
@@ -141,8 +141,8 @@ func (pubKey PubKey) VerifyBytes(msg []byte, sig []byte) bool {
 		return false
 	}
 	publicKey, _ := bls.PublicKeyFromBytes(pubKey)
-	aggregationInfo := bls.AggregationInfoFromMsg(publicKey,msg)
-	blsSignature, _ := bls.SignatureFromBytesWithAggregationInfo(sig,aggregationInfo)
+	aggregationInfo := bls.AggregationInfoFromMsg(publicKey, msg)
+	blsSignature, _ := bls.SignatureFromBytesWithAggregationInfo(sig, aggregationInfo)
 	return blsSignature.Verify()
 }
 

--- a/crypto/bls12381/bls12381_test.go
+++ b/crypto/bls12381/bls12381_test.go
@@ -33,6 +33,6 @@ func TestBLSAddress(t *testing.T) {
 	privKey := bls12381.PrivKey(decodedPrivateKeyBytes)
 	pubKey := privKey.PubKey()
 	address := pubKey.Address()
-	assert.EqualValues(t,decodedPublicKeyBytes,pubKey)
-	assert.EqualValues(t,decodedAddressBytes,address)
+	assert.EqualValues(t, decodedPublicKeyBytes, pubKey)
+	assert.EqualValues(t, decodedAddressBytes, address)
 }


### PR DESCRIPTION
This adds error checking (was missing in several places) and sets modOrder flag to true so the bytes wrap around when greater than the mod order for private keys.

@QuantumExplorer  I assume the bug you reported is probably from setting the 2nd arg in bls.PrivateKeyFromBytes to false when it should probably be true since you are getting them from a random source.

Then it was probably 0 bytes or something so might have "worked" for signing but nothing to be freed. But this is just a guess, can you test this w/these changes and see how it goes? You can also just add the err handling but re-set the flag to false (e.g.: `bls.PrivateKeyFromBytes(privKey, false)`) to see if the error tells you anything.